### PR TITLE
Return audio object instead of true

### DIFF
--- a/audiosynth.js
+++ b/audiosynth.js
@@ -159,7 +159,7 @@ var Synth, AudioSynth, AudioSynthInstrument;
 		var src = this.generate(sound, note, octave, duration);
 		var audio = new Audio(src);
 		audio.play();
-		return true;
+		return audio;
 	});
 	setPub('debug', function() { this._debug = true; });
 	setPub('createInstrument', function(sound) {


### PR DESCRIPTION
Allows the developer to work with the audio object directly and check playback status, stop, etc...
